### PR TITLE
Add sorting by fissure tier

### DIFF
--- a/src/commands/Ondemand/Fissures.js
+++ b/src/commands/Ondemand/Fissures.js
@@ -24,7 +24,7 @@ class Fissures extends Command {
     this.bot.settings.getChannelPlatform(message.channel)
       .then(platform => this.bot.worldStates[platform].getData())
       .then((ws) => {
-        const fissures = ws.fissures;
+        const fissures = ws.fissures.sort((a, b) => { return a.tierNum > b.TierNum; });
         this.messageManager.embed(message,
           new FissureEmbed(this.bot, fissures), true, false);
       })


### PR DESCRIPTION
This sorts the fissures in the list in ascending order according to tier, starting with Lith and ending with Axi.

#71 